### PR TITLE
add - python3 to apt-get statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get upgrade -y \
   ripgrep \
   nodejs \
   npm \
+  python3 \
+  python3-pip \
   && locale-gen ja_JP.UTF-8 \
   && echo "export LANG=ja_JP.UTF-8" >> ~/.bashrc \
   && npm install n -g \


### PR DESCRIPTION
# English
## Background
I couldn't get a Neovim plugin to work because it depends on Python.

## Modification
1. Add python3 to the packages installed via apt-get.

# 背景（Original）
Pythonに依存しているNeovimのプラグインを動作させられなかった。

# 修正
1. apt-getでインストールするパッケージにpython3を追加