### PR TITLE
add - container_name to docker-compose, because the automatically assigned name was redundant

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         GIT_EMAIL: ${GIT_EMAIL}
         NVIM_CONF_URL: ${NVIM_CONF_URL}
         NVIM_DATA_URL: ${NVIM_DATA_URL}
+    container_name: ${CONTAINER_NAME}
     environment:
       TZ: "Asia/Tokyo"
     volumes:


### PR DESCRIPTION
# Background
After launching a container, there are times when I want to specify the container name (for example, with docker exec). However, if the container name is automatically assigned, I have to remember the rules for assigning container names. Finding this cumbersome, I have enabled explicit specification of container names.

# 背景（Original）
コンテナを起動した後、（例えばdocker execなどで）コンテナ名を指定したいことがある。しかし、コンテナ名が自動で割り当てられていると、コンテナ名の割り当てルールを覚えておかなければならない。しかし、それは面倒に感じたので、明示的にコンテナの名前を指定できるようにした。