### PR TITLE
modify - initial.sh to specify the container name as command-line argument

### DIFF
--- a/initial.sh
+++ b/initial.sh
@@ -7,10 +7,15 @@
 # 3. 他のコンテナの/usr/ディレクトリが/mnt/usr/としてマウントされていること。
 ### 利用方法
 # `docker compose up`等でコンテナを作成した後、コンテナに入らない状態で実行する。
+# 第一引数に開発環境のコンテナ名を指定する。
 ### 注意点
 # これはbashスクリプトなので、コンテナの外でも実行できてしまう。
 # しかし、コンテナ外で実行されると、コンテナ外の環境が変わるかもしれない。
 # そのためこのスクリプトでは、`docker exec`コマンドを利用することで、
 # コンテナの外で実行してもコンテナ外の環境が変わらないことを保証している。
 
-docker exec -u 0 nvimcontainer-nvim-1 rsync -rl /mnt/usr/ /usr
+if [[ -z "$1" ]]; then
+  echo "Please specify the container name."
+else
+  docker exec -u 0 $1 rsync -rl /mnt/usr/ /usr
+fi


### PR DESCRIPTION
# Background
I modified the docker-compose.yml to allow users to specify the container name, consequently, I updated initial.sh to accept any container name as input.

# 背景（Original）
docker-compose.ymlを変更して、コンテナ名をユーザが指定できるように変更したため、initial.shも任意のコンテナ名を受け取れるようにした。